### PR TITLE
Handle quotes in issue titles

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         title: ${{ github.event.issue.title }}
       with:
         script: |
-          const newTitle = process.env.title + ' ' + [${{ steps.create_jira_issue.outputs.issue }}]
+          const newTitle = process.env.title + ' [${{ steps.create_jira_issue.outputs.issue }}]
           github.issues.update({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/action.yml
+++ b/action.yml
@@ -52,12 +52,11 @@ runs:
       uses: actions/github-script@v4.0.2
       with:
         script: |
-          const newTitle = `${{ github.event.issue.title }} [${{ steps.create_jira_issue.outputs.issue }}]`
           github.issues.update({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: newTitle
+            title: ${{ github.event.issue.title }} [${{ steps.create_jira_issue.outputs.issue }}]
           })
     - name: Add comment to GitHub issue
       uses: actions/github-script@v4.0.2

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         title: ${{ github.event.issue.title }}
       with:
         script: |
-          const newTitle = process.env.title + ' [${{ steps.create_jira_issue.outputs.issue }}]
+          const newTitle = process.env.title + ` [${{ steps.create_jira_issue.outputs.issue }}]`
           github.issues.update({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/action.yml
+++ b/action.yml
@@ -50,13 +50,16 @@ runs:
 
     - name: Update title of GitHub issue
       uses: actions/github-script@v4.0.2
+      env:
+        title: ${{ github.event.issue.title }}
       with:
         script: |
+          const newTitle = process.env.title + ' ' + [${{ steps.create_jira_issue.outputs.issue }}]
           github.issues.update({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: ${{ github.event.issue.title }} [${{ steps.create_jira_issue.outputs.issue }}]
+            title: newTitle
           })
     - name: Add comment to GitHub issue
       uses: actions/github-script@v4.0.2


### PR DESCRIPTION
If the issue's title contains `, the action breaks.

Post-merge, this needs to be released or deployed to be accessible in the main Hazelcast repo(s).

Fixes #2